### PR TITLE
Alternative configurable deploy excludes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,12 +50,12 @@ svn update --set-depth infinity trunk
 
 echo "➤ Copying files..."
 if [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
-	echo "Using .distignore"
+	echo "ℹ︎ Using .distignore"
 	# Copy from current branch to /trunk, excluding dotorg assets
 	# The --delete flag will delete anything in destination that no longer exists in source
 	rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete
 else
-	echo "Using .gitattributes"
+	echo "ℹ︎ Using .gitattributes"
 
 	cd "$GITHUB_WORKSPACE"
 


### PR DESCRIPTION
Fix https://github.com/10up/actions-wordpress/issues/1, ref https://github.com/10up/actions-wordpress/issues/7 and can satisfy https://github.com/10up/actions-wordpress/issues/3

Replace https://github.com/10up/actions-wordpress/pull/14

---
This PR aims to let the source of files to deploy be easily configurable.

If `GITHUB_TOKEN` is provided, the process is exactly the same.
If not provided, we fallback to local files.
Using local files helps solving https://github.com/10up/actions-wordpress/issues/3, where we can use GitHub Actions with layers.

![image](https://user-images.githubusercontent.com/846943/58842730-d84e1b00-866f-11e9-899b-9355ade68268.png)

We use `.distignore` as suggested in #1 to ignore file with rsync while letting this be configurable.

The documentation may require an update, but let me know your thoughts on this first.