### PR TITLE
Check if ASSETS_DIR actually exists before copying

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,6 +94,8 @@ fi
 # Copy dotorg assets to /assets
 if [[ -d "$GITHUB_WORKSPACE/$ASSETS_DIR/" ]]; then
 	rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete
+else
+	echo "ℹ︎ No assets directory found; skipping asset copy"
 fi
 
 # Add everything and commit to SVN

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,7 +92,9 @@ else
 fi
 
 # Copy dotorg assets to /assets
-rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete
+if [[ -d "$GITHUB_WORKSPACE/$ASSETS_DIR/" ]]; then
+	rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete
+fi
 
 # Add everything and commit to SVN
 # The force flag ensures we recurse into subdirectories even if they are already added


### PR DESCRIPTION
### Description of the Change

Added a check to verify that `ASSETS_DIR` actually exists before attempting to copy assets over. Fixes #7  

### Benefits

This would avoid the following error when no ASSETS_DIR is present: 

```
rsync: change_dir "/github/workspace/.wordpress-org" failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1207) [sender=3.1.3]
##[error]Docker run failed with exit code 23
```

### Possible Drawbacks

None I can think of.

### Verification Process

Tested the affected portion of the script locally. 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.
